### PR TITLE
update: fix ts core plugin to work with r2frida-compile

### DIFF
--- a/r2-plugin-core-ts/src/coreplug.r2.ts
+++ b/r2-plugin-core-ts/src/coreplug.r2.ts
@@ -1,4 +1,5 @@
-import { r2, R, NativePointer } from  "r2papi";
+import type { R2PipeSync } from "r2papi";
+declare const r2: R2PipeSync;
 
 function InstantiateCorePlugin() {
     r2.unload("core", "mycore");


### PR DESCRIPTION
## Problem
The current import causes `r2` to be `undefined` when compiled with r2frida-compile, breaking the plugin with `TypeError: cannot read property 'unload' of undefined`.

## Solution
Use `import type` to preserve TypeScript type hints while using the global `r2` object injected by r2frida-compile.

## Changes
```diff
- import { r2, R, NativePointer } from  "r2papi";
+ import type { R2PipeSync } from "r2papi";
+ declare const r2: R2PipeSync;

